### PR TITLE
Fix `guard.py` and `run.py` typehints

### DIFF
--- a/guardrails/cli.py
+++ b/guardrails/cli.py
@@ -12,7 +12,7 @@ def compile_rail(rail: str, out: str) -> None:
     raise NotImplementedError("Currently compiling rail is not supported.")
 
 
-def validate_llm_output(rail: str, llm_output: str) -> bool:
+def validate_llm_output(rail: str, llm_output: str) -> dict:
     """Validate guardrails.yml file."""
     guard = Guard.from_rail(rail)
     result = guard.parse(llm_output)

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -441,6 +441,20 @@ class Guard:
         self,
         llm_output: str,
         metadata: Optional[Dict] = None,
+        llm_api: None = None,
+        num_reasks: int = 1,
+        prompt_params: Optional[Dict] = None,
+        full_schema_reask: Optional[bool] = None,
+        *args,
+        **kwargs,
+    ) -> Dict:
+        ...
+
+    @overload
+    def parse(
+        self,
+        llm_output: str,
+        metadata: Optional[Dict] = None,
         llm_api: Callable[[Any], Awaitable[Any]] = ...,
         num_reasks: int = 1,
         prompt_params: Optional[Dict] = None,
@@ -468,7 +482,7 @@ class Guard:
         self,
         llm_output: str,
         metadata: Optional[Dict] = None,
-        llm_api: Optional[Union[Callable, Callable[[Any], Awaitable[Any]]]] = None,
+        llm_api: Optional[Callable] = None,
         num_reasks: int = 1,
         prompt_params: Optional[Dict] = None,
         full_schema_reask: Optional[bool] = None,

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -64,7 +64,7 @@ class Guard:
         self.base_model = base_model
 
     @property
-    def input_schema(self) -> Schema:
+    def input_schema(self) -> Optional[Schema]:
         """Return the input schema."""
         return self.rail.input_schema
 
@@ -74,17 +74,17 @@ class Guard:
         return self.rail.output_schema
 
     @property
-    def instructions(self) -> Instructions:
+    def instructions(self) -> Optional[Instructions]:
         """Return the instruction-prompt."""
         return self.rail.instructions
 
     @property
-    def prompt(self) -> Prompt:
+    def prompt(self) -> Optional[Prompt]:
         """Return the prompt."""
         return self.rail.prompt
 
     @property
-    def raw_prompt(self) -> Prompt:
+    def raw_prompt(self) -> Optional[Prompt]:
         """Return the prompt, alias for `prompt`."""
         return self.prompt
 

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -508,7 +508,9 @@ class AsyncArbitraryCallable(AsyncPromptCallableBase):
         )
 
 
-def get_async_llm_ask(llm_api: Callable[[Any], Awaitable[Any]], *args, **kwargs):
+def get_async_llm_ask(
+    llm_api: Callable[[Any], Awaitable[Any]], *args, **kwargs
+) -> AsyncPromptCallableBase:
     if llm_api == openai.Completion.acreate:
         return AsyncOpenAICallable(*args, **kwargs)
     elif llm_api == openai.ChatCompletion.acreate:

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -311,11 +311,7 @@ def get_llm_ask(llm_api: Callable, *args, **kwargs) -> PromptCallableBase:
 ###
 
 
-class AsyncPromptCallableBase:
-    def __init__(self, *args, **kwargs):
-        self.init_args = args
-        self.init_kwargs = kwargs
-
+class AsyncPromptCallableBase(PromptCallableBase):
     async def invoke_llm(
         self,
         *args,

--- a/guardrails/prompt/base_prompt.py
+++ b/guardrails/prompt/base_prompt.py
@@ -97,6 +97,8 @@ class BasePrompt:
         if earliest_match_idx is None:
             return 0
 
+        if earliest_match is None:
+            return None
         return earliest_match.start()
 
     def escape(self) -> str:

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -33,16 +33,16 @@ class Rail:
         4. `<instructions>`, which contains the instructions to be passed to the LLM
     """
 
-    input_schema: Optional[Schema] = (None,)
-    output_schema: Optional[Schema] = (None,)
-    instructions: Optional[Instructions] = (None,)
-    prompt: Optional[Prompt] = (None,)
-    version: Optional[str] = ("0.1",)
+    input_schema: Schema
+    output_schema: Schema
+    instructions: Instructions
+    prompt: Prompt
+    version: str = "0.1"
 
     @classmethod
     def from_pydantic(
         cls,
-        output_class: BaseModel,
+        output_class: Type[BaseModel],
         prompt: Optional[str] = None,
         instructions: Optional[str] = None,
         reask_prompt: Optional[str] = None,

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -444,7 +444,7 @@ class Runner:
     def prepare_to_loop(
         self,
         reasks: list,
-        validated_output: Optional[Dict],
+        validated_output: Optional[Union[Dict, ReAsk]],
         output_schema: Schema,
         prompt_params: Dict,
         include_instructions: bool = False,

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -1,9 +1,9 @@
 import copy
 import logging
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 from eliot import add_destinations, start_action
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from guardrails.datatypes import verify_metadata_requirements
 from guardrails.llm_providers import AsyncPromptCallableBase, PromptCallableBase
@@ -23,7 +23,7 @@ actions_logger = logging.getLogger(f"{__name__}.actions")
 add_destinations(actions_logger.debug)
 
 
-class Runner(BaseModel):
+class Runner:
     """Runner class that calls an LLM API with a prompt, and performs input and
     output validation.
 
@@ -42,58 +42,69 @@ class Runner(BaseModel):
         guard_history: The guard history to use, defaults to an empty history.
     """
 
-    class Config:
-        arbitrary_types_allowed = True
+    def __init__(
+        self,
+        output_schema: Schema,
+        guard_state: GuardState,
+        num_reasks: int,
+        prompt: Optional[Union[str, Prompt]] = None,
+        instructions: Optional[Union[str, Instructions]] = None,
+        msg_history: Optional[List[Dict]] = None,
+        api: Optional[PromptCallableBase] = None,
+        input_schema: Optional[Schema] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        output: Optional[str] = None,
+        reask_prompt: Optional[Prompt] = None,
+        reask_instructions: Optional[Instructions] = None,
+        guard_history: Optional[GuardHistory] = None,
+        base_model: Optional[Type[BaseModel]] = None,
+        full_schema_reask: bool = False,
+    ):
+        if prompt:
+            assert api, "Must provide an API if a prompt is provided."
+            assert not output, "Cannot provide both a prompt and output."
 
-    instructions: Optional[Union[str, Instructions]]
-    prompt: Optional[Union[str, Prompt]]
-    msg_history: Optional[List[Dict]]
-    api: Optional[PromptCallableBase]
-    input_schema: Optional[Schema]
-    output_schema: Schema
-    guard_state: GuardState
-    num_reasks: int
-    metadata: Dict[str, Any] = Field(default_factory=dict)
-    output: Optional[str] = None
-    reask_prompt: Optional[Prompt] = None
-    reask_instructions: Optional[Instructions] = None
-    guard_history: GuardHistory = Field(
-        default_factory=lambda: GuardHistory(history=[])
-    )
-    base_model: Optional[Type[BaseModel]] = None
-    full_schema_reask: bool = False
+        if isinstance(prompt, str):
+            self.prompt = Prompt(prompt, output_schema=output_schema.transpile())
+        else:
+            self.prompt = prompt
+
+        if isinstance(instructions, str):
+            self.instructions = Instructions(
+                instructions, output_schema=output_schema.transpile()
+            )
+        else:
+            self.instructions = instructions
+
+        if msg_history:
+            msg_history = copy.deepcopy(msg_history)
+            msg_history_copy = []
+            for msg in msg_history:
+                msg["content"] = Prompt(
+                    msg["content"], output_schema=output_schema.transpile()
+                )
+                msg_history_copy.append(msg)
+            self.msg_history = msg_history_copy
+        else:
+            self.msg_history = None
+
+        self.api = api
+        self.input_schema = input_schema
+        self.output_schema = output_schema
+        self.guard_state = guard_state
+        self.num_reasks = num_reasks
+        self.metadata = metadata or {}
+        self.output = output
+        self.reask_prompt = reask_prompt
+        self.reask_instructions = reask_instructions
+        self.guard_history = guard_history or GuardHistory(history=[])
+        self.base_model = base_model
+        self.full_schema_reask = full_schema_reask
 
     def _reset_guard_history(self):
         """Reset the guard history."""
         self.guard_history = GuardHistory(history=[])
         self.guard_state.push(self.guard_history)
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        if self.prompt:
-            assert self.api, "Must provide an API if a prompt is provided."
-            assert not self.output, "Cannot provide both a prompt and output."
-
-        if isinstance(self.prompt, str):
-            self.prompt = Prompt(
-                self.prompt, output_schema=self.output_schema.transpile()
-            )
-
-        if isinstance(self.instructions, str):
-            self.instructions = Instructions(
-                self.instructions, output_schema=self.output_schema.transpile()
-            )
-
-        if self.msg_history is not None and len(self.msg_history):
-            self.msg_history = copy.deepcopy(self.msg_history)
-            msg_history = []
-            for msg in self.msg_history:
-                msg["content"] = Prompt(
-                    msg["content"], output_schema=self.output_schema.transpile()
-                )
-                msg_history.append(msg)
-            self.msg_history = msg_history
 
     def __call__(self, prompt_params: Optional[Dict] = None) -> GuardHistory:
         """Execute the runner by repeatedly calling step until the reask budget
@@ -108,6 +119,7 @@ class Runner(BaseModel):
         """
         if prompt_params is None:
             prompt_params = {}
+
         # check if validator requirements are fulfilled
         missing_keys = verify_metadata_requirements(
             self.metadata, self.output_schema.to_dict().values()
@@ -265,13 +277,16 @@ class Runner(BaseModel):
         api: Optional[Union[PromptCallableBase, AsyncPromptCallableBase]],
         input_schema: Optional[Schema],
         output_schema: Schema,
-    ) -> Tuple[Instructions, Prompt, List[Dict]]:
+    ) -> Tuple[Optional[Instructions], Optional[Prompt], Optional[List[Dict]]]:
         """Prepare by running pre-processing and input validation.
 
         Returns:
             The instructions, prompt, and message history.
         """
         with start_action(action_type="prepare", index=index) as action:
+            if api is None:
+                raise ValueError("API must be provided.")
+
             if prompt_params is None:
                 prompt_params = {}
 
@@ -282,7 +297,7 @@ class Runner(BaseModel):
                     msg["content"] = msg["content"].format(**prompt_params)
 
                 prompt, instructions = None, None
-            else:
+            elif prompt is not None:
                 if isinstance(prompt, str):
                     prompt = Prompt(prompt)
 
@@ -296,6 +311,8 @@ class Runner(BaseModel):
                 instructions, prompt = output_schema.preprocess_prompt(
                     api, instructions, prompt
                 )
+            else:
+                raise ValueError("Prompt or message history must be provided.")
 
             action.log(
                 message_type="info",
@@ -313,7 +330,7 @@ class Runner(BaseModel):
         instructions: Optional[Instructions],
         prompt: Optional[Prompt],
         msg_history: Optional[List[Dict[str, str]]],
-        api: Optional[Callable],
+        api: Optional[PromptCallableBase],
         output: Optional[str] = None,
     ) -> LLMResponse:
         """Run a step.
@@ -323,45 +340,38 @@ class Runner(BaseModel):
         3. Log the output
         """
 
-        def msg_history_source(msg_history) -> List[Dict[str, str]]:
-            msg_history_copy = copy.deepcopy(msg_history)
-            for msg in msg_history_copy:
-                msg["content"] = msg["content"].source
-            return msg_history_copy
-
         with start_action(action_type="call", index=index, prompt=prompt) as action:
-            llm_response = None
-            try:
-                if msg_history:
+            if api is None:
+                if output is None:
+                    raise ValueError("API or output must be provided.")
+                llm_response = LLMResponse(
+                    output=output,
+                )
+            elif msg_history:
+                try:
                     llm_response = api(
                         msg_history=msg_history_source(msg_history),
                         base_model=self.base_model,
                     )
-                else:
-                    if prompt and instructions:
-                        llm_response = api(
-                            prompt.source,
-                            instructions=instructions.source,
-                            base_model=self.base_model,
-                        )
-                    elif prompt:
-                        llm_response = api(prompt.source, base_model=self.base_model)
-            except Exception:
-                # If the API call fails, try calling again without the base model.
-                if msg_history:
+                except Exception:
+                    # If the API call fails, try calling again without the base model.
                     llm_response = api(msg_history=msg_history_source(msg_history))
-                else:
-                    if prompt and instructions:
-                        llm_response = api(
-                            prompt.source, instructions=instructions.source
-                        )
-                    elif prompt:
-                        llm_response = api(prompt.source)
-
-            if llm_response is None:
-                llm_response = LLMResponse(
-                    output=output,
-                )
+            elif prompt and instructions:
+                try:
+                    llm_response = api(
+                        prompt.source,
+                        instructions=instructions.source,
+                        base_model=self.base_model,
+                    )
+                except Exception:
+                    llm_response = api(prompt.source, instructions=instructions.source)
+            elif prompt:
+                try:
+                    llm_response = api(prompt.source, base_model=self.base_model)
+                except Exception:
+                    llm_response = api(prompt.source)
+            else:
+                raise ValueError("Prompt or message history must be provided.")
 
             action.log(
                 message_type="info",
@@ -439,7 +449,7 @@ class Runner(BaseModel):
         output_schema: Schema,
         prompt_params: Dict,
         include_instructions: bool = False,
-    ) -> Tuple[Prompt, Instructions, Schema, Optional[List[Dict]]]:
+    ) -> Tuple[Prompt, Optional[Instructions], Schema, Optional[List[Dict]]]:
         """Prepare to loop again."""
         output_schema, prompt, instructions = output_schema.get_reask_setup(
             reasks=reasks,
@@ -454,9 +464,44 @@ class Runner(BaseModel):
 
 
 class AsyncRunner(Runner):
-    api: Optional[AsyncPromptCallableBase]
+    def __init__(
+        self,
+        output_schema: Schema,
+        guard_state: GuardState,
+        num_reasks: int,
+        prompt: Optional[Union[str, Prompt]] = None,
+        instructions: Optional[Union[str, Instructions]] = None,
+        msg_history: Optional[List[Dict]] = None,
+        api: Optional[AsyncPromptCallableBase] = None,
+        input_schema: Optional[Schema] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        output: Optional[str] = None,
+        reask_prompt: Optional[Prompt] = None,
+        reask_instructions: Optional[Instructions] = None,
+        guard_history: Optional[GuardHistory] = None,
+        base_model: Optional[Type[BaseModel]] = None,
+        full_schema_reask: bool = False,
+    ):
+        super().__init__(
+            output_schema=output_schema,
+            guard_state=guard_state,
+            num_reasks=num_reasks,
+            prompt=prompt,
+            instructions=instructions,
+            msg_history=msg_history,
+            api=api,
+            input_schema=input_schema,
+            metadata=metadata,
+            output=output,
+            reask_prompt=reask_prompt,
+            reask_instructions=reask_instructions,
+            guard_history=guard_history,
+            base_model=base_model,
+            full_schema_reask=full_schema_reask,
+        )
+        self.api: Optional[AsyncPromptCallableBase] = api
 
-    async def async_run(self, prompt_params: Dict = None) -> GuardHistory:
+    async def async_run(self, prompt_params: Optional[Dict] = None) -> GuardHistory:
         """Execute the runner by repeatedly calling step until the reask budget
         is exhausted.
 
@@ -467,6 +512,8 @@ class AsyncRunner(Runner):
         Returns:
             The guard history.
         """
+        if prompt_params is None:
+            prompt_params = {}
         self._reset_guard_history()
 
         # check if validator requirements are fulfilled
@@ -525,14 +572,14 @@ class AsyncRunner(Runner):
     async def async_step(
         self,
         index: int,
-        api: AsyncPromptCallableBase,
+        api: Optional[AsyncPromptCallableBase],
         instructions: Optional[Instructions],
-        prompt: Prompt,
+        prompt: Optional[Prompt],
         msg_history: Optional[List[Dict]],
         prompt_params: Dict,
-        input_schema: Schema,
+        input_schema: Optional[Schema],
         output_schema: Schema,
-        output: str = None,
+        output: Optional[str] = None,
     ):
         guard_logs = GuardLogs()
         self.guard_history.push(guard_logs)
@@ -547,7 +594,11 @@ class AsyncRunner(Runner):
             output_schema=output_schema,
         ):
             # Prepare: run pre-processing, and input validation.
-            if not output:
+            if output:
+                instructions = None
+                prompt = None
+                msg_history = None
+            else:
                 instructions, prompt, msg_history = self.prepare(
                     index,
                     instructions,
@@ -558,9 +609,6 @@ class AsyncRunner(Runner):
                     input_schema,
                     output_schema,
                 )
-            else:
-                instructions = None
-                prompt = None
 
             guard_logs.prompt = prompt
             guard_logs.instructions = instructions
@@ -609,9 +657,9 @@ class AsyncRunner(Runner):
         self,
         index: int,
         instructions: Optional[Instructions],
-        prompt: Prompt,
+        prompt: Optional[Prompt],
         msg_history: Optional[List[Dict]],
-        api: AsyncPromptCallableBase,
+        api: Optional[AsyncPromptCallableBase],
         output: Optional[str] = None,
     ) -> LLMResponse:
         """Run a step.
@@ -621,40 +669,41 @@ class AsyncRunner(Runner):
         3. Log the output
         """
         with start_action(action_type="call", index=index, prompt=prompt) as action:
-            llm_response = None
-            try:
-                if msg_history:
-                    llm_response = await api(
-                        msg_history=msg_history,
-                        base_model=self.base_model,
-                    )
-                else:
-                    if prompt and instructions:
-                        llm_response = await api(
-                            prompt.source,
-                            instructions=instructions.source,
-                            base_model=self.base_model,
-                        )
-                    elif prompt:
-                        llm_response = await api(
-                            prompt.source, base_model=self.base_model
-                        )
-            except Exception:
-                # If the API call fails, try calling again without the base model.
-                if msg_history:
-                    llm_response = await api(msg_history=msg_history)
-                else:
-                    if prompt and instructions:
-                        llm_response = await api(
-                            prompt.source, instructions=instructions.source
-                        )
-                    elif prompt:
-                        llm_response = await api(prompt.source)
-
-            if llm_response is None:
+            if output is not None:
                 llm_response = LLMResponse(
                     output=output,
                 )
+            elif api is None:
+                raise ValueError("Either API or output must be provided.")
+            elif msg_history:
+                try:
+                    llm_response = await api(
+                        msg_history=msg_history_source(msg_history),
+                        base_model=self.base_model,
+                    )
+                except Exception:
+                    # If the API call fails, try calling again without the base model.
+                    llm_response = await api(
+                        msg_history=msg_history_source(msg_history)
+                    )
+            elif prompt and instructions:
+                try:
+                    llm_response = await api(
+                        prompt.source,
+                        instructions=instructions.source,
+                        base_model=self.base_model,
+                    )
+                except Exception:
+                    llm_response = await api(
+                        prompt.source, instructions=instructions.source
+                    )
+            elif prompt:
+                try:
+                    llm_response = await api(prompt.source, base_model=self.base_model)
+                except Exception:
+                    llm_response = await api(prompt.source)
+            else:
+                raise ValueError("Output, prompt or message history must be provided.")
 
             action.log(
                 message_type="info",
@@ -682,3 +731,10 @@ class AsyncRunner(Runner):
             )
 
             return validated_output
+
+
+def msg_history_source(msg_history) -> List[Dict[str, str]]:
+    msg_history_copy = copy.deepcopy(msg_history)
+    for msg in msg_history_copy:
+        msg["content"] = msg["content"].source
+    return msg_history_copy

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -1,10 +1,9 @@
 import copy
 import logging
-from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from eliot import add_destinations, start_action
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from guardrails.datatypes import verify_metadata_requirements
 from guardrails.llm_providers import AsyncPromptCallableBase, PromptCallableBase
@@ -24,8 +23,7 @@ actions_logger = logging.getLogger(f"{__name__}.actions")
 add_destinations(actions_logger.debug)
 
 
-@dataclass
-class Runner:
+class Runner(BaseModel):
     """Runner class that calls an LLM API with a prompt, and performs input and
     output validation.
 

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -235,8 +235,7 @@ class Runner:
             raw_output = llm_response.output
 
             # Parse: parse the output.
-            parsed_output, parsing_error = self.parse(index, output, output_schema)
-            parsed_output = self.parse(index, raw_output, output_schema)
+            parsed_output, parsing_error = self.parse(index, raw_output, output_schema)
 
             guard_logs.parsed_output = parsed_output
 

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -42,7 +42,7 @@ class FieldValidationLogs(ArbitraryModel):
 class LLMResponse(ArbitraryModel):
     prompt_token_count: Optional[int] = None
     response_token_count: Optional[int] = None
-    output: Optional[str] = None
+    output: str
 
 
 class GuardLogs(ArbitraryModel):

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from pydantic import BaseModel, Field, PrivateAttr
 from rich.console import Group
@@ -52,7 +52,7 @@ class GuardLogs(ArbitraryModel):
     msg_history: Optional[List[Dict[str, Prompt]]] = None
     parsed_output: Optional[dict] = None
     validated_output: Optional[dict] = None
-    reasks: Optional[List[ReAsk]] = None
+    reasks: Optional[Sequence[ReAsk]] = None
 
     field_validation_logs: Optional[FieldValidationLogs] = None
 
@@ -173,7 +173,7 @@ class GuardHistory(ArbitraryModel):
 
 
 class GuardState(ArbitraryModel):
-    all_histories: List[GuardHistory]
+    all_histories: List[GuardHistory] = Field(default_factory=list)
 
     def push(self, guard_history: GuardHistory) -> None:
         self.all_histories += [guard_history]


### PR DESCRIPTION
Based on #4, merge that first.

This PR fixes the typehints in `guard.py`, and some associated references (namely `run.py`).