### PR TITLE
error handling around guard execution

### DIFF
--- a/guardrails/applications/text2sql.py
+++ b/guardrails/applications/text2sql.py
@@ -180,7 +180,7 @@ class Text2Sql:
             similar_examples_prompt = ""
 
         try:
-            return self.guard(
+            output = self.guard(
                 self.llm_api,
                 prompt_params={
                     "nl_instruction": text,

--- a/guardrails/applications/text2sql.py
+++ b/guardrails/applications/text2sql.py
@@ -180,7 +180,7 @@ class Text2Sql:
             similar_examples_prompt = ""
 
         try:
-            output = self.guard(
+            return self.guard(
                 self.llm_api,
                 prompt_params={
                     "nl_instruction": text,
@@ -188,7 +188,7 @@ class Text2Sql:
                     "db_info": str(self.sql_schema),
                 },
                 **self.llm_api_kwargs,
-            )[1]["generated_sql"]
+            ).validated_output["generated_sql"]
         except TypeError:
             output = None
 

--- a/guardrails/classes/validation_outcome.py
+++ b/guardrails/classes/validation_outcome.py
@@ -54,14 +54,6 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
             )
             print(result)
             return result
-    
-    @classmethod
-    def from_exception(cls, error_message: str): 
-        return cls[T](
-                raw_llm_output='',
-                validation_passed=False,
-                exception=error_message
-        )
 
     def __iter__(self):
         as_tuple = (

--- a/guardrails/classes/validation_outcome.py
+++ b/guardrails/classes/validation_outcome.py
@@ -26,7 +26,7 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
         " the LLM output passed validation."
         "  If this is False, the validated_output may be invalid."
     )
-    exception: Optional[str] = Field()
+    error: Optional[str] = Field()
 
     @classmethod
     def from_guard_history(cls, guard_history: GuardHistory, error_message: Optional[str]):
@@ -37,7 +37,7 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
             return cls[T](
                 raw_llm_output=raw_output or "",
                 validation_passed=False,
-                exception=error_message,
+                error=error_message,
             )
         elif isinstance(validated_output, ReAsk):
             return cls[T](
@@ -61,7 +61,7 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
             self.validated_output,
             self.reask,
             self.validation_passed,
-            self.exception,
+            self.error,
         )
         return iter(as_tuple)
 

--- a/guardrails/classes/validation_outcome.py
+++ b/guardrails/classes/validation_outcome.py
@@ -29,22 +29,31 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
     exception: Optional[str] = Field()
 
     @classmethod
-    def from_guard_history(cls, guard_history: GuardHistory):
+    def from_guard_history(cls, guard_history: GuardHistory, error_message: Optional[str]):
         raw_output = guard_history.output
         validated_output = guard_history.validated_output
         any_validations_failed = len(guard_history.failed_validations) > 0
-        if isinstance(validated_output, ReAsk):
+        if(error_message): 
+            return cls[T](
+                raw_llm_output=raw_output or "",
+                validation_passed=False,
+                exception=error_message,
+            )
+        elif isinstance(validated_output, ReAsk):
             return cls[T](
                 raw_llm_output=raw_output,
                 reask=validated_output,
                 validation_passed=any_validations_failed,
             )
         else:
-            return cls[T](
+            print("else")
+            result = cls[T](
                 raw_llm_output=raw_output,
                 validated_output=validated_output,
                 validation_passed=any_validations_failed,
             )
+            print(result)
+            return result
     
     @classmethod
     def from_exception(cls, error_message: str): 

--- a/guardrails/classes/validation_outcome.py
+++ b/guardrails/classes/validation_outcome.py
@@ -29,11 +29,13 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
     error: Optional[str] = Field()
 
     @classmethod
-    def from_guard_history(cls, guard_history: GuardHistory, error_message: Optional[str]):
+    def from_guard_history(
+        cls, guard_history: GuardHistory, error_message: Optional[str]
+    ):
         raw_output = guard_history.output
         validated_output = guard_history.validated_output
         any_validations_failed = len(guard_history.failed_validations) > 0
-        if(error_message): 
+        if error_message:
             return cls[T](
                 raw_llm_output=raw_output or "",
                 validation_passed=False,
@@ -46,14 +48,11 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
                 validation_passed=any_validations_failed,
             )
         else:
-            print("else")
-            result = cls[T](
+            return cls[T](
                 raw_llm_output=raw_output,
                 validated_output=validated_output,
                 validation_passed=any_validations_failed,
             )
-            print(result)
-            return result
 
     def __iter__(self):
         as_tuple = (

--- a/guardrails/classes/validation_outcome.py
+++ b/guardrails/classes/validation_outcome.py
@@ -26,6 +26,7 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
         " the LLM output passed validation."
         "  If this is False, the validated_output may be invalid."
     )
+    exception: Optional[str] = Field()
 
     @classmethod
     def from_guard_history(cls, guard_history: GuardHistory):
@@ -44,6 +45,14 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
                 validated_output=validated_output,
                 validation_passed=any_validations_failed,
             )
+    
+    @classmethod
+    def from_exception(cls, error_message: str): 
+        return cls[T](
+                raw_llm_output='',
+                validation_passed=False,
+                exception=error_message
+        )
 
     def __iter__(self):
         as_tuple = (
@@ -51,6 +60,7 @@ class ValidationOutcome(Generic[T], ArbitraryModel):
             self.validated_output,
             self.reask,
             self.validation_passed,
+            self.exception,
         )
         return iter(as_tuple)
 

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -231,7 +231,18 @@ class Guard(Generic[T]):
         )
         return cls[str](rail, num_reasks=num_reasks)
 
+    def handle_error(func): 
+        def wrapper(self, *args, **kwargs):
+            try:
+                return func(self, *args, **kwargs)
+            except Exception as e:
+                error_message = str(e)
+                return ValidationOutcome[T].from_exception(error_message)
+
+        return wrapper
+    
     @overload
+    @handle_error
     def __call__(
         self,
         llm_api: Callable[[Any], Awaitable[Any]],
@@ -248,6 +259,7 @@ class Guard(Generic[T]):
         ...
 
     @overload
+    @handle_error
     def __call__(
         self,
         llm_api: Callable,
@@ -263,6 +275,7 @@ class Guard(Generic[T]):
     ) -> ValidationOutcome[T]:
         ...
 
+    @handle_error
     def __call__(
         self,
         llm_api: Union[Callable, Callable[[Any], Awaitable[Any]]],
@@ -447,8 +460,9 @@ class Guard(Generic[T]):
 
     def __rich_repr__(self):
         yield "RAIL", self.rail
-
+    
     @overload
+    @handle_error
     def parse(
         self,
         llm_output: str,
@@ -463,6 +477,7 @@ class Guard(Generic[T]):
         ...
 
     @overload
+    @handle_error
     def parse(
         self,
         llm_output: str,
@@ -477,6 +492,7 @@ class Guard(Generic[T]):
         ...
 
     @overload
+    @handle_error
     def parse(
         self,
         llm_output: str,
@@ -490,6 +506,7 @@ class Guard(Generic[T]):
     ) -> ValidationOutcome[T]:
         ...
 
+    @handle_error
     def parse(
         self,
         llm_output: str,
@@ -647,3 +664,4 @@ class Guard(Generic[T]):
                 guard_history.validated_output
             )
             return ValidationOutcome[T].from_guard_history(guard_history)
+    

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -230,7 +230,7 @@ class Guard(Generic[T]):
             reask_instructions=reask_instructions,
         )
         return cls[str](rail, num_reasks=num_reasks)
-    
+
     @overload
     def __call__(
         self,
@@ -439,7 +439,9 @@ class Guard(Generic[T]):
                 guard_state=self.guard_state,
                 full_schema_reask=full_schema_reask,
             )
-            guard_history, error_message = await runner.async_run(prompt_params=prompt_params)
+            guard_history, error_message = await runner.async_run(
+                prompt_params=prompt_params
+            )
             return ValidationOutcome[T].from_guard_history(guard_history, error_message)
 
     def __repr__(self):
@@ -447,7 +449,7 @@ class Guard(Generic[T]):
 
     def __rich_repr__(self):
         yield "RAIL", self.rail
-    
+
     @overload
     def parse(
         self,
@@ -489,6 +491,7 @@ class Guard(Generic[T]):
         **kwargs,
     ) -> ValidationOutcome[T]:
         ...
+
     def parse(
         self,
         llm_output: str,
@@ -599,7 +602,9 @@ class Guard(Generic[T]):
             guard_history.history[-1].validated_output = sub_reasks_with_fixed_values(
                 guard_history.validated_output
             )
-            validation_outcome = ValidationOutcome[T].from_guard_history(guard_history, error_message)
+            validation_outcome = ValidationOutcome[T].from_guard_history(
+                guard_history, error_message
+            )
             return validation_outcome
 
     async def _async_parse(
@@ -641,9 +646,10 @@ class Guard(Generic[T]):
                 guard_state=self.guard_state,
                 full_schema_reask=full_schema_reask,
             )
-            guard_history, error_message = await runner.async_run(prompt_params=prompt_params)
+            guard_history, error_message = await runner.async_run(
+                prompt_params=prompt_params
+            )
             guard_history.history[-1].validated_output = sub_reasks_with_fixed_values(
                 guard_history.validated_output
             )
             return ValidationOutcome[T].from_guard_history(guard_history, error_message)
-    

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -106,7 +106,20 @@ class Runner:
         self.guard_history = GuardHistory(history=[])
         self.guard_state.push(self.guard_history)
 
-    def __call__(self, prompt_params: Optional[Dict] = None) -> GuardHistory:
+    def handle_error(func): 
+        def wrapper(self, *args, **kwargs):
+            error_message = None
+            try:
+                guard_history = func(self, *args, **kwargs)
+            except Exception as e:
+                error_message = str(e)
+                guard_history = self.guard_history
+            return guard_history, error_message
+
+        return wrapper
+    
+    @handle_error
+    def __call__(self, prompt_params: Optional[Dict] = None) -> Tuple[GuardHistory, str]:
         """Execute the runner by repeatedly calling step until the reask budget
         is exhausted.
 
@@ -500,7 +513,20 @@ class AsyncRunner(Runner):
         )
         self.api: Optional[AsyncPromptCallableBase] = api
 
-    async def async_run(self, prompt_params: Optional[Dict] = None) -> GuardHistory:
+    def handle_error(func): 
+        async def wrapper(self, *args, **kwargs):
+            error_message = None
+            try:
+                guard_history = await func(self, *args, **kwargs)
+            except Exception as e:
+                error_message = str(e)
+                guard_history = self.guard_history
+            return guard_history, error_message
+
+        return wrapper
+
+    @handle_error
+    async def async_run(self, prompt_params: Optional[Dict] = None) -> Tuple[GuardHistory, str]:
         """Execute the runner by repeatedly calling step until the reask budget
         is exhausted.
 

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -106,7 +106,7 @@ class Runner:
         self.guard_history = GuardHistory(history=[])
         self.guard_state.push(self.guard_history)
 
-    def handle_error(func): 
+    def handle_error(func):
         def wrapper(self, *args, **kwargs):
             error_message = None
             try:
@@ -117,9 +117,11 @@ class Runner:
             return guard_history, error_message
 
         return wrapper
-    
+
     @handle_error
-    def __call__(self, prompt_params: Optional[Dict] = None) -> Tuple[GuardHistory, str]:
+    def __call__(
+        self, prompt_params: Optional[Dict] = None
+    ) -> Tuple[GuardHistory, str]:
         """Execute the runner by repeatedly calling step until the reask budget
         is exhausted.
 
@@ -513,7 +515,7 @@ class AsyncRunner(Runner):
         )
         self.api: Optional[AsyncPromptCallableBase] = api
 
-    def handle_error(func): 
+    def handle_error(func):
         async def wrapper(self, *args, **kwargs):
             error_message = None
             try:
@@ -526,7 +528,9 @@ class AsyncRunner(Runner):
         return wrapper
 
     @handle_error
-    async def async_run(self, prompt_params: Optional[Dict] = None) -> Tuple[GuardHistory, str]:
+    async def async_run(
+        self, prompt_params: Optional[Dict] = None
+    ) -> Tuple[GuardHistory, str]:
         """Execute the runner by repeatedly calling step until the reask budget
         is exhausted.
 


### PR DESCRIPTION
Add error handling around guard execution --  in the case of error, we are no longer throwing, we will return the error along with any llm output